### PR TITLE
Fix demo banner dismissal

### DIFF
--- a/src/components/charts/IncomeChart.tsx
+++ b/src/components/charts/IncomeChart.tsx
@@ -43,13 +43,22 @@ const IncomeChart: React.FC<IncomeChartProps> = ({ data, currency = 'USD' }) => 
   const amounts = data.map(item => item.total);
   const [growth, setGrowth] = useState<number>(0);
   
-  // Calculate growth percentage
+  // Calculate growth percentage, avoid division by zero
   useEffect(() => {
     if (amounts.length >= 2) {
       const oldest = amounts[0];
       const newest = amounts[amounts.length - 1];
-      const growthPercent = ((newest - oldest) / oldest) * 100;
-      setGrowth(growthPercent);
+
+      if (oldest === 0) {
+        // When the initial value is 0, growth is undefined
+        setGrowth(0);
+      } else {
+        const growthPercent = ((newest - oldest) / oldest) * 100;
+        setGrowth(growthPercent);
+      }
+    } else {
+      // Not enough data points, assume no growth
+      setGrowth(0);
     }
   }, [amounts]);
 

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -60,6 +60,7 @@ const Dashboard = () => {
   const [loadingStats, setLoadingStats] = useState(true);
   const [loadingEvents, setLoadingEvents] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showDemoBanner, setShowDemoBanner] = useState(true);
 
   // Redirect if not logged in
   useEffect(() => {
@@ -241,7 +242,7 @@ const Dashboard = () => {
           </div>
         )}
 
-        {sampleData && (
+        {sampleData && showDemoBanner && (
           <div className="bg-blue-50 border border-blue-200 text-blue-700 p-4 mb-6 rounded-md shadow-sm flex items-start" role="alert">
             <div className="p-1 bg-blue-100 rounded-md mr-3">
               <svg className="h-5 w-5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -258,7 +259,10 @@ const Dashboard = () => {
                 </svg>
               </Link>
             </div>
-            <button className="ml-auto text-blue-500 hover:text-blue-700">
+            <button
+              className="ml-auto text-blue-500 hover:text-blue-700"
+              onClick={() => setShowDemoBanner(false)}
+            >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>

--- a/src/utils/dbConnect.ts
+++ b/src/utils/dbConnect.ts
@@ -5,7 +5,7 @@ declare global {
   var mongooseConnection: {
     isConnected?: number;
     promise?: Promise<typeof mongoose>;
-    connectionAttempts?: number;
+    connectionAttempts: number;
   };
 }
 


### PR DESCRIPTION
## Summary
- add state for dismissing the demo banner on Dashboard
- prevent division by zero when calculating growth in IncomeChart
- fix dbConnect type definition

## Testing
- `npm test` *(fails: no tests found)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6849ed795510833382a5de978d97ae10