### PR TITLE
Fix demo login without MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MoneyGuide
 
-MoneyGuide is a minimalistic financial dashboard web application that helps users monitor and manage their passive income streams. The app provides an intuitive interface for manually inputting income data, visualizing trends with charts and a calendar view, and offering a centralized overview of your financial situation.
+MoneyGuide is a minimalistic financial dashboard web application that helps users track their income and spending. The app provides an intuitive interface for manually inputting transactions, visualizing trends with charts and a calendar view, and offering a centralized overview of your financial situation.
 
 ## MVP Features
 
@@ -8,14 +8,14 @@ MoneyGuide is a minimalistic financial dashboard web application that helps user
   - Email/Password sign-up and login
   - Google OAuth for seamless registration
 
-- **Passive Income Dashboard:**
+- **Finance Dashboard:**
   - Manual entry of income sources with the following fields:
     - **Source:** Description of the income stream
     - **Amount:** The income value
     - **Frequency:** How often the income is received (e.g., weekly, monthly)
   - CRUD operations for managing income records
   - Data visualizations:
-    - **Line Chart:** Displaying total passive income trends over the past 6 months
+    - **Line Chart:** Displaying income trends over the past 6 months
     - **Calendar View:** Visualizing income events by date
 
 - **Future Enhancements:**

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -59,6 +59,14 @@ const Layout: React.FC<LayoutProps> = ({ children, title = 'MoneyGuide' }) => {
                           <span className="hidden sm:inline">Income</span>
                         </span>
                       </Link>
+                      <Link href="/expenses" className={`px-3 py-2 rounded-md text-sm font-medium transition-all ${isActive('/expenses') ? 'bg-primary/10 text-primary' : 'text-gray-600 hover:text-primary hover:bg-gray-50'}`}>
+                        <span className="flex items-center">
+                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                          </svg>
+                          <span className="hidden sm:inline">Expenses</span>
+                        </span>
+                      </Link>
                       <div className="relative ml-2 group">
                         <button 
                           className="flex items-center px-3 py-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors"

--- a/src/components/charts/IncomeChart.tsx
+++ b/src/components/charts/IncomeChart.tsx
@@ -43,13 +43,22 @@ const IncomeChart: React.FC<IncomeChartProps> = ({ data, currency = 'USD' }) => 
   const amounts = data.map(item => item.total);
   const [growth, setGrowth] = useState<number>(0);
   
-  // Calculate growth percentage
+  // Calculate growth percentage, avoid division by zero
   useEffect(() => {
     if (amounts.length >= 2) {
       const oldest = amounts[0];
       const newest = amounts[amounts.length - 1];
-      const growthPercent = ((newest - oldest) / oldest) * 100;
-      setGrowth(growthPercent);
+
+      if (oldest === 0) {
+        // When the initial value is 0, growth is undefined
+        setGrowth(0);
+      } else {
+        const growthPercent = ((newest - oldest) / oldest) * 100;
+        setGrowth(growthPercent);
+      }
+    } else {
+      // Not enough data points, assume no growth
+      setGrowth(0);
     }
   }, [amounts]);
 

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -33,52 +33,78 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
+    const { email, password } = req.body;
+
+    // Validation
+    if (!email || !password) {
+      return res.status(400).json({
+        success: false,
+        message: 'Email and password are required'
+      });
+    }
+
+    // If demo credentials are provided, bypass the DB connection entirely
+    if (email === 'demo@example.com' && password === 'password123') {
+      const demoUser = { _id: 'demo-user', name: 'Demo User', email };
+      const token = generateToken(demoUser);
+
+      // Set cookie with token
+      setCookie('token', token, {
+        req,
+        res,
+        maxAge: 60 * 60 * 24 * 7, // 1 week
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/'
+      });
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          id: demoUser._id,
+          name: demoUser.name,
+          email: demoUser.email,
+        }
+      });
+    }
+
     // Connect to the database with improved error handling
     try {
       // First attempt with 30 second timeout
       const dbPromise = dbConnect();
-      const timeout = new Promise((_, reject) => 
+      const timeout = new Promise((_, reject) =>
         setTimeout(() => reject(new Error('Database connection timeout (30s)')), 30000)
       );
-      
+
       await Promise.race([dbPromise, timeout]);
-      
+
       console.log('Database connected successfully on first attempt');
     } catch (error) {
       console.error('Database connection failed on first attempt. Waiting 2s before retry...');
-      
+
       // Log detailed error information
       console.error('Connection error details:', error instanceof Error ? error.message : 'Unknown error');
-      
+
       // Wait a moment before retry
       await new Promise(resolve => setTimeout(resolve, 2000));
-      
+
       // Try again with an even longer timeout (45 seconds)
       try {
         const retryPromise = dbConnect();
-        const retryTimeout = new Promise((_, reject) => 
+        const retryTimeout = new Promise((_, reject) =>
           setTimeout(() => reject(new Error('Database connection timeout on retry (45s)')), 45000)
         );
-        
+
         await Promise.race([retryPromise, retryTimeout]);
         console.log('Database connected successfully on retry attempt');
       } catch (retryError) {
         console.error('Database connection failed on retry attempt');
         console.error('Retry error details:', retryError instanceof Error ? retryError.message : 'Unknown error');
-        
+
         // Throw a user-friendly error that will be caught by the outer try/catch
         throw new Error('Unable to connect to the database after multiple attempts. Please try again later.');
       }
-    }
-
-    const { email, password } = req.body;
-
-    // Validation
-    if (!email || !password) {
-      return res.status(400).json({ 
-        success: false, 
-        message: 'Email and password are required' 
-      });
     }
 
     // Find user in MongoDB

--- a/src/pages/api/income/calendar.ts
+++ b/src/pages/api/income/calendar.ts
@@ -5,9 +5,7 @@ import { authenticateUser, AuthRequest } from '@/utils/auth';
 import { startOfMonth, endOfMonth } from 'date-fns';
 
 async function handler(req: AuthRequest, res: NextApiResponse) {
-  await dbConnect();
-  
-  const { 
+  const {
     method,
     query: { month, year }
   } = req;
@@ -16,6 +14,44 @@ async function handler(req: AuthRequest, res: NextApiResponse) {
   if (!req.user) {
     return res.status(401).json({ success: false, message: 'Authentication required' });
   }
+
+  // Demo user returns static events without DB access
+  if (req.user.id === 'demo-user') {
+    const currentDate = new Date();
+    const targetMonth = month ? parseInt(month as string, 10) - 1 : currentDate.getMonth();
+    const targetYear = year ? parseInt(year as string, 10) : currentDate.getFullYear();
+
+    const sampleEvents = [
+      {
+        id: 'sample-1',
+        title: 'Dividend Income',
+        amount: 125.5,
+        currency: 'USD',
+        date: new Date(targetYear, targetMonth, 15),
+        frequency: 'monthly'
+      },
+      {
+        id: 'sample-2',
+        title: 'Rental Income',
+        amount: 875.0,
+        currency: 'USD',
+        date: new Date(targetYear, targetMonth, 1),
+        frequency: 'monthly'
+      },
+      {
+        id: 'sample-3',
+        title: 'Side Project',
+        amount: 250.25,
+        currency: 'USD',
+        date: new Date(targetYear, targetMonth, 22),
+        frequency: 'quarterly'
+      }
+    ];
+
+    return res.status(200).json({ success: true, data: sampleEvents });
+  }
+
+  await dbConnect();
 
   const userId = req.user.id;
 

--- a/src/pages/api/income/stats.ts
+++ b/src/pages/api/income/stats.ts
@@ -5,6 +5,26 @@ import { authenticateUser, AuthRequest } from '@/utils/auth';
 import { startOfMonth, subMonths, format, endOfMonth } from 'date-fns';
 
 async function handler(req: AuthRequest, res: NextApiResponse) {
+  // If demo user, return static data without hitting the database
+  if (req.user?.id === 'demo-user') {
+    const demoMonthlyStats = [
+      { month: 'Aug 2023', total: 950.25 },
+      { month: 'Sep 2023', total: 975.5 },
+      { month: 'Oct 2023', total: 1050.0 },
+      { month: 'Nov 2023', total: 1125.3 },
+      { month: 'Dec 2023', total: 1175.45 },
+      { month: 'Jan 2024', total: 1250.75 },
+    ];
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        totalMonthlyIncome: 1250.75,
+        monthlyStats: demoMonthlyStats,
+      },
+    });
+  }
+
   await dbConnect();
   
   const { method } = req;

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -60,6 +60,7 @@ const Dashboard = () => {
   const [loadingStats, setLoadingStats] = useState(true);
   const [loadingEvents, setLoadingEvents] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showDemoBanner, setShowDemoBanner] = useState(true);
 
   // Redirect if not logged in
   useEffect(() => {
@@ -196,7 +197,7 @@ const Dashboard = () => {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
                   </svg>
                 </span>
-                Passive Income Dashboard
+                Income & Spending Dashboard
               </h1>
               <p className="text-gray-600 text-lg">
                 Welcome back, <span className="font-medium">{user?.name}</span>! 
@@ -215,6 +216,12 @@ const Dashboard = () => {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
                 </svg>
                 Add Income
+              </Link>
+              <Link href="/expenses" className="btn-secondary flex items-center px-4 py-2 text-sm shadow-md hover:shadow-lg">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 12H6" />
+                </svg>
+                Add Expense
               </Link>
             </div>
           </div>
@@ -241,7 +248,7 @@ const Dashboard = () => {
           </div>
         )}
 
-        {sampleData && (
+        {sampleData && showDemoBanner && (
           <div className="bg-blue-50 border border-blue-200 text-blue-700 p-4 mb-6 rounded-md shadow-sm flex items-start" role="alert">
             <div className="p-1 bg-blue-100 rounded-md mr-3">
               <svg className="h-5 w-5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -258,7 +265,10 @@ const Dashboard = () => {
                 </svg>
               </Link>
             </div>
-            <button className="ml-auto text-blue-500 hover:text-blue-700">
+            <button
+              className="ml-auto text-blue-500 hover:text-blue-700"
+              onClick={() => setShowDemoBanner(false)}
+            >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
@@ -392,7 +402,7 @@ const Dashboard = () => {
         <div className="flex justify-between items-center mb-6">
           <div>
             <h2 className="text-2xl font-semibold">Income Trends</h2>
-            <p className="text-gray-600 mt-1">See how your passive income has grown over time</p>
+            <p className="text-gray-600 mt-1">See how your income trends evolve over time</p>
           </div>
           <div className="flex items-center space-x-3">
             <div className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-full flex items-center">

--- a/src/pages/expenses/index.tsx
+++ b/src/pages/expenses/index.tsx
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import Layout from '@/components/Layout';
+import { useAuth } from '@/utils/AuthContext';
+
+const ExpensesPage = () => {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push('/login');
+    }
+  }, [user, loading, router]);
+
+  if (loading || (!user && !loading)) {
+    return null;
+  }
+
+  return (
+    <Layout title="Expenses - MoneyGuide">
+      <div className="section-spacing">
+        <h1 className="text-3xl font-bold mb-3">Expenses</h1>
+        <p className="text-gray-600 mb-6">Track and manage your spending. This section is coming soon.</p>
+      </div>
+    </Layout>
+  );
+};
+
+export default ExpensesPage;

--- a/src/pages/income/index.tsx
+++ b/src/pages/income/index.tsx
@@ -131,7 +131,7 @@ const IncomePage = () => {
   }
 
   return (
-    <Layout title="Passive Income - MoneyGuide">
+    <Layout title="Income - MoneyGuide">
       <div className="section-spacing">
         <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-6 bg-gradient-to-r from-primary/5 to-secondary/5 p-8 rounded-xl shadow-sm border border-gray-100 mb-6">
           <div>
@@ -141,10 +141,10 @@ const IncomePage = () => {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
               </span>
-              Passive Income
+              Income
             </h1>
             <p className="text-gray-600 text-lg">
-              Manage all your passive income sources and track your financial growth over time.
+              Manage all your income sources and track your financial growth over time.
             </p>
           </div>
           <button 
@@ -195,7 +195,7 @@ const IncomePage = () => {
         <div className="flex justify-between items-center mb-8">
           <div>
             <h2 className="text-2xl font-semibold">Your Income Sources</h2>
-            <p className="text-gray-600 mt-1">Track and manage all your passive income streams</p>
+            <p className="text-gray-600 mt-1">Track and manage all your income streams</p>
           </div>
           <div className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-full flex items-center">
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1.5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -312,7 +312,7 @@ const IncomePage = () => {
               </svg>
             </div>
             <p className="font-medium text-xl mb-2">No income sources found</p> 
-            <p className="text-lg mb-8">Add your first income source to start tracking your passive income progress.</p>
+            <p className="text-lg mb-8">Add your first income source to start tracking your income progress.</p>
             {!showForm && (
               <button 
                 onClick={() => setShowForm(true)} 
@@ -330,9 +330,9 @@ const IncomePage = () => {
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-blue-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span className="font-medium text-gray-700">Why track passive income?</span>
+                <span className="font-medium text-gray-700">Why track your income?</span>
               </div>
-              <p className="text-gray-600">Passive income sources provide financial security and freedom over time. By tracking your progress here, you can visualize growth and make informed decisions about your financial future.</p>
+              <p className="text-gray-600">Monitoring your income provides financial security and freedom over time. By tracking your progress here, you can visualize growth and make informed decisions about your financial future.</p>
             </div>
           </div>
         )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,7 @@ const Home: React.FC = () => {
             Take Control of Your Financial Future
           </h1>
           <p className="text-xl text-gray-600 max-w-2xl mb-10 leading-relaxed">
-            MoneyGuide helps you track your passive income, expenses, investments, and net worth in one place. 
+            MoneyGuide helps you track your income, spending, investments, and net worth in one place.
             <span className="font-medium">Get started in under 2 minutes.</span>
           </p>
 
@@ -62,9 +62,9 @@ const Home: React.FC = () => {
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
-          <h2 className="text-2xl font-semibold mb-3 text-center">Track Passive Income</h2>
+          <h2 className="text-2xl font-semibold mb-3 text-center">Track Income & Spending</h2>
           <p className="text-gray-600 text-center">
-            Monitor all your income streams in one place. Get real-time updates on your earnings without the hassle.
+            Monitor all your cash flow in one place. Get real-time updates on earnings and expenses without the hassle.
           </p>
         </div>
 

--- a/src/utils/dbConnect.ts
+++ b/src/utils/dbConnect.ts
@@ -5,7 +5,7 @@ declare global {
   var mongooseConnection: {
     isConnected?: number;
     promise?: Promise<typeof mongoose>;
-    connectionAttempts?: number;
+    connectionAttempts: number;
   };
 }
 


### PR DESCRIPTION
## Summary
- allow login with demo credentials without a database connection
- provide demo stats and calendar data for demo user
- expand the dashboard wording from passive income to full income & spending tracking
- add Expenses link and placeholder page

## Testing
- `npm test` *(fails: no tests found)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6849ed795510833382a5de978d97ae10